### PR TITLE
0.3.1: Include README.md in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/icinga2api/__init__.py
+++ b/icinga2api/__init__.py
@@ -6,4 +6,4 @@
 
 __author__ = 'fmnisme, Tobias von der Krone'
 __contact__ = 'fmnisme@gmail.com, tobias@vonderkrone.info'
-__version__ = '0.3'
+__version__ = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 PACKAGE = "icinga2api"
 NAME = "python-icinga2api"
@@ -9,9 +8,6 @@ AUTHOR_EMAIL = "fmnisme@gmail.com, tobias@vonderkrone.info"
 URL = "https://github.com/tobiasvdk/python-icinga2api"
 VERSION = __import__(PACKAGE).__version__
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
 setup(
     name=NAME,
     version=VERSION,
@@ -20,7 +16,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     license="BSD",
     url=URL,
-    packages=find_packages(),
+    packages=[PACKAGE],
     zip_safe=False,
-    long_description=read('README.md'),
+    long_description=open("README.md").read(),
 )


### PR DESCRIPTION
This fixes issue #4, where the package fails to install because the README.md file is missing.

This also simplifies setup.py slightly.