### PR TITLE
Bug fix and feature enhancement

### DIFF
--- a/icinga2api/base.py
+++ b/icinga2api/base.py
@@ -152,7 +152,7 @@ class Base(object):
 
         # TODO: test iter_lines()
         message = ''
-        for char in stream.iter_content():
+        for char in stream.iter_content(decode_unicode=True):
             if char == '\n':
                 yield message
                 message = ''

--- a/icinga2api/base.py
+++ b/icinga2api/base.py
@@ -158,7 +158,8 @@ class Base(object):
 
         # TODO: test iter_lines()
         message = ''
-        for char in stream.iter_content(decode_unicode=True):
+        for char in stream.iter_content():
+            char = char.decode()
             if char == '\n':
                 yield message
                 message = ''

--- a/icinga2api/base.py
+++ b/icinga2api/base.py
@@ -127,12 +127,18 @@ class Base(object):
         # pprint(response)
 
         if not 200 <= response.status_code <= 299:
+            try:
+                upstream_error=response.json()
+            except ValueError:
+                upstream_error=None
             raise Icinga2ApiException(
                 'Request "{}" failed with status {}: {}'.format(
                     response.url,
                     response.status_code,
                     response.text,
-                ))
+                ),
+                upstream_error=upstream_error,
+            )
 
         if stream:
             return response

--- a/icinga2api/exceptions.py
+++ b/icinga2api/exceptions.py
@@ -31,9 +31,10 @@ class Icinga2ApiException(Exception):
     Icinga 2 API exception class
     '''
 
-    def __init__(self, error):
+    def __init__(self, error, upstream_error=None):
         super(Icinga2ApiException, self).__init__(error)
         self.error = error
+        self.upstream_error = upstream_error
 
     def __str__(self):
         return str(self.error)


### PR DESCRIPTION
I encountered a bug in event streaming mode, namely the byte array returned by `request.iter_content` needs to be decoded to a string.

Additionally I added a small feature enhancement. Object requests now decode and add the json error message returned by Icinga to the exception raised on requests with non 2xx result codes.