### PR TITLE
Update for Python3.7 compatibility

### DIFF
--- a/icinga2api/base.py
+++ b/icinga2api/base.py
@@ -157,4 +157,4 @@ class Base(object):
                 yield message
                 message = ''
             else:
-                message += char
+                message += str(char)

--- a/icinga2api/base.py
+++ b/icinga2api/base.py
@@ -151,10 +151,10 @@ class Base(object):
         '''
 
         # TODO: test iter_lines()
-        message = ''
+        message = b''
         for char in stream.iter_content():
-            if char == '\n':
-                yield message
-                message = ''
+            if char == b'\n':
+                yield message.decode('unicode_escape')
+                message = b''
             else:
-                message += str(char)
+                message += char


### PR DESCRIPTION
When running under Python 3.7 and exception is being raised
```
Traceback (most recent call last):
  File "/opt/stackstorm/packs/icinga2/sensors/icinga2_state_change_events.py", line 51, in run
    for event in self.client.events.subscribe(self.types, self.queue):
  File "/opt/stackstorm/virtualenvs/icinga2/src/icinga2api/icinga2api/events.py", line 85, in subscribe
    for event in self._get_message_from_stream(stream):
  File "/opt/stackstorm/virtualenvs/icinga2/src/icinga2api/icinga2api/base.py", line 160, in _get_message_from_stream
    message += char
TypeError: can only concatenate str (not "bytes") to str
```
The patch explicitly casts the byte string to unicode string.